### PR TITLE
Added refresh for property inventory

### DIFF
--- a/client/property.lua
+++ b/client/property.lua
@@ -4,6 +4,7 @@ AddEventHandler(
     function(data)
         setPropertyInventoryData(data)
         openPropertyInventory()
+        refreshPropertyInventory()
     end
 )
 


### PR DESCRIPTION
Before, people complained about their properties were empty even tho they had items in their inventories. This is fixed now, just by refreshing the items right after the menu is opened.